### PR TITLE
1.21 Minecraft Attributes to be usable by Stats Mechanic and Class Attributes

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
+++ b/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
@@ -1949,35 +1949,36 @@ public class PlayerData {
         }
 
         // Others stats
+        // Min and Max Values determined by the following: https://minecraft.wiki/w/Attribute
         this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_SPEED, AttributeManager.ATTACK_SPEED, 0, 1024);
         this.updateMCAttribute(player, Attribute.GENERIC_ARMOR, AttributeManager.ARMOR, 0, 30);
         this.updateMCAttribute(player, Attribute.GENERIC_LUCK, AttributeManager.LUCK, -1024, 1024);
         this.updateMCAttribute(player, Attribute.GENERIC_KNOCKBACK_RESISTANCE, AttributeManager.KNOCKBACK_RESIST, 0, 1.0);
         this.updateMCAttribute(player, Attribute.GENERIC_ARMOR_TOUGHNESS, AttributeManager.ARMOR_TOUGHNESS, 0, 20);
         // Stats added in 1.21+
-        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_DAMAGE, AttributeManager.ATTACK_DAMAGE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_KNOCKBACK, AttributeManager.ATTACK_KNOCKBACK, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_FLYING_SPEED, AttributeManager.FLYING_SPEED, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_FOLLOW_RANGE, AttributeManager.FOLLOW_RANGE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_MAX_ABSORPTION, AttributeManager.ABSORPTION, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_SCALE, AttributeManager.SCALE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_STEP_HEIGHT, AttributeManager.STEP_HEIGHT, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_JUMP_STRENGTH, AttributeManager.JUMP_STRENGTH, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_GRAVITY, AttributeManager.GRAVITY, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_SAFE_FALL_DISTANCE, AttributeManager.SAFE_FALL_DISTANCE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER, AttributeManager.FALL_DAMAGE_MULTIPLIER, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_BURNING_TIME, AttributeManager.BURNING_TIME, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_DAMAGE, AttributeManager.ATTACK_DAMAGE, 0.0f, 2048.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_KNOCKBACK, AttributeManager.ATTACK_KNOCKBACK, 0.0f, 5.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_FLYING_SPEED, AttributeManager.FLYING_SPEED, 0.0f, 1024.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_FOLLOW_RANGE, AttributeManager.FOLLOW_RANGE, 0.0f, 2048.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_MAX_ABSORPTION, AttributeManager.ABSORPTION, 0.0f, 2048.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_SCALE, AttributeManager.SCALE, 0.0625f, 16.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_STEP_HEIGHT, AttributeManager.STEP_HEIGHT, 0.0f, 10.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_JUMP_STRENGTH, AttributeManager.JUMP_STRENGTH, 0.0f, 32.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_GRAVITY, AttributeManager.GRAVITY, -1.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_SAFE_FALL_DISTANCE, AttributeManager.SAFE_FALL_DISTANCE, -1024.0f, 1024.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER, AttributeManager.FALL_DAMAGE_MULTIPLIER, 0.0f, 100.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_BURNING_TIME, AttributeManager.BURNING_TIME, 0.0f, 1024.0f);
         this.updateMCAttribute(player, Attribute.GENERIC_EXPLOSION_KNOCKBACK_RESISTANCE, AttributeManager.EXPLOSION_KNOCKBACK_RESISTANCE, 0.0f, 1.0f);
         this.updateMCAttribute(player, Attribute.GENERIC_MOVEMENT_EFFICIENCY, AttributeManager.MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_OXYGEN_BONUS, AttributeManager.OXYGEN_BONUS, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_OXYGEN_BONUS, AttributeManager.OXYGEN_BONUS, 0.0f, 1024.0f);
         this.updateMCAttribute(player, Attribute.GENERIC_WATER_MOVEMENT_EFFICIENCY, AttributeManager.WATER_MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
         // Player only stats 1.21+
-        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_INTERACTION_RANGE, AttributeManager.BLOCK_INTERACTION_RANGE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_ENTITY_INTERACTION_RANGE, AttributeManager.ENTITY_INTERACTION_RANGE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_BREAK_SPEED, AttributeManager.BLOCK_BREAK_SPEED, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_MINING_EFFICIENCY, AttributeManager.MINING_EFFICIENCY, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_INTERACTION_RANGE, AttributeManager.BLOCK_INTERACTION_RANGE, 0.0f, 64.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_ENTITY_INTERACTION_RANGE, AttributeManager.ENTITY_INTERACTION_RANGE, 0.0f, 64.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_BREAK_SPEED, AttributeManager.BLOCK_BREAK_SPEED, 0.0f, 1024.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_MINING_EFFICIENCY, AttributeManager.MINING_EFFICIENCY, 0.0f, 1024.0f);
         this.updateMCAttribute(player, Attribute.PLAYER_SNEAKING_SPEED, AttributeManager.SNEAKING_SPEED, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_SUBMERGED_MINING_SPEED, AttributeManager.SUBMERGED_MINING_SPEED, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_SUBMERGED_MINING_SPEED, AttributeManager.SUBMERGED_MINING_SPEED, 0.0f, 20.0f);
         this.updateMCAttribute(player, Attribute.PLAYER_SWEEPING_DAMAGE_RATIO, AttributeManager.SWEEPING_DAMAGE_RATIO, 0.0f, 1.0f);
 
     }

--- a/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
+++ b/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
@@ -77,6 +77,7 @@ import studio.magemonkey.fabled.manager.AttributeManager;
 import studio.magemonkey.fabled.manager.FabledAttribute;
 import studio.magemonkey.fabled.manager.IAttributeManager;
 import studio.magemonkey.fabled.task.ScoreboardTask;
+import studio.magemonkey.codex.core.Version;
 
 import java.util.*;
 import java.util.Map.Entry;
@@ -1955,33 +1956,34 @@ public class PlayerData {
         this.updateMCAttribute(player, Attribute.GENERIC_LUCK, AttributeManager.LUCK, -1024, 1024);
         this.updateMCAttribute(player, Attribute.GENERIC_KNOCKBACK_RESISTANCE, AttributeManager.KNOCKBACK_RESIST, 0, 1.0);
         this.updateMCAttribute(player, Attribute.GENERIC_ARMOR_TOUGHNESS, AttributeManager.ARMOR_TOUGHNESS, 0, 20);
-        // Stats added in 1.21+
-        
-        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_DAMAGE, AttributeManager.ATTACK_DAMAGE, 0.0f, 2048.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_KNOCKBACK, AttributeManager.ATTACK_KNOCKBACK, 0.0f, 5.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_FLYING_SPEED, AttributeManager.FLYING_SPEED, 0.0f, 1024.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_FOLLOW_RANGE, AttributeManager.FOLLOW_RANGE, 0.0f, 2048.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_MAX_ABSORPTION, AttributeManager.ABSORPTION, 0.0f, 2048.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_SCALE, AttributeManager.SCALE, 0.0625f, 16.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_STEP_HEIGHT, AttributeManager.STEP_HEIGHT, 0.0f, 10.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_JUMP_STRENGTH, AttributeManager.JUMP_STRENGTH, 0.0f, 32.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_GRAVITY, AttributeManager.GRAVITY, -1.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_SAFE_FALL_DISTANCE, AttributeManager.SAFE_FALL_DISTANCE, -1024.0f, 1024.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER, AttributeManager.FALL_DAMAGE_MULTIPLIER, 0.0f, 100.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_BURNING_TIME, AttributeManager.BURNING_TIME, 0.0f, 1024.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_EXPLOSION_KNOCKBACK_RESISTANCE, AttributeManager.EXPLOSION_KNOCKBACK_RESISTANCE, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_MOVEMENT_EFFICIENCY, AttributeManager.MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_OXYGEN_BONUS, AttributeManager.OXYGEN_BONUS, 0.0f, 1024.0f);
-        this.updateMCAttribute(player, Attribute.GENERIC_WATER_MOVEMENT_EFFICIENCY, AttributeManager.WATER_MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
-        // Player only stats 1.21+
-        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_INTERACTION_RANGE, AttributeManager.BLOCK_INTERACTION_RANGE, 0.0f, 64.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_ENTITY_INTERACTION_RANGE, AttributeManager.ENTITY_INTERACTION_RANGE, 0.0f, 64.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_BREAK_SPEED, AttributeManager.BLOCK_BREAK_SPEED, 0.0f, 1024.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_MINING_EFFICIENCY, AttributeManager.MINING_EFFICIENCY, 0.0f, 1024.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_SNEAKING_SPEED, AttributeManager.SNEAKING_SPEED, 0.0f, 1.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_SUBMERGED_MINING_SPEED, AttributeManager.SUBMERGED_MINING_SPEED, 0.0f, 20.0f);
-        this.updateMCAttribute(player, Attribute.PLAYER_SWEEPING_DAMAGE_RATIO, AttributeManager.SWEEPING_DAMAGE_RATIO, 0.0f, 1.0f);
-
+        // Initialize 1.21+ attributes only if version is 1.21+
+        if (Version.CURRENT.isAtLeast(Version.V1_21_R1)) {
+            // Generic stats 1.21+
+            this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_DAMAGE, AttributeManager.ATTACK_DAMAGE, 0.0f, 2048.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_KNOCKBACK, AttributeManager.ATTACK_KNOCKBACK, 0.0f, 5.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_FLYING_SPEED, AttributeManager.FLYING_SPEED, 0.0f, 1024.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_FOLLOW_RANGE, AttributeManager.FOLLOW_RANGE, 0.0f, 2048.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_MAX_ABSORPTION, AttributeManager.ABSORPTION, 0.0f, 2048.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_SCALE, AttributeManager.SCALE, 0.0625f, 16.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_STEP_HEIGHT, AttributeManager.STEP_HEIGHT, 0.0f, 10.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_JUMP_STRENGTH, AttributeManager.JUMP_STRENGTH, 0.0f, 32.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_GRAVITY, AttributeManager.GRAVITY, -1.0f, 1.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_SAFE_FALL_DISTANCE, AttributeManager.SAFE_FALL_DISTANCE, -1024.0f, 1024.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER, AttributeManager.FALL_DAMAGE_MULTIPLIER, 0.0f, 100.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_BURNING_TIME, AttributeManager.BURNING_TIME, 0.0f, 1024.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_EXPLOSION_KNOCKBACK_RESISTANCE, AttributeManager.EXPLOSION_KNOCKBACK_RESISTANCE, 0.0f, 1.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_MOVEMENT_EFFICIENCY, AttributeManager.MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_OXYGEN_BONUS, AttributeManager.OXYGEN_BONUS, 0.0f, 1024.0f);
+            this.updateMCAttribute(player, Attribute.GENERIC_WATER_MOVEMENT_EFFICIENCY, AttributeManager.WATER_MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
+            // Player only stats 1.21+
+            this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_INTERACTION_RANGE, AttributeManager.BLOCK_INTERACTION_RANGE, 0.0f, 64.0f);
+            this.updateMCAttribute(player, Attribute.PLAYER_ENTITY_INTERACTION_RANGE, AttributeManager.ENTITY_INTERACTION_RANGE, 0.0f, 64.0f);
+            this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_BREAK_SPEED, AttributeManager.BLOCK_BREAK_SPEED, 0.0f, 1024.0f);
+            this.updateMCAttribute(player, Attribute.PLAYER_MINING_EFFICIENCY, AttributeManager.MINING_EFFICIENCY, 0.0f, 1024.0f);
+            this.updateMCAttribute(player, Attribute.PLAYER_SNEAKING_SPEED, AttributeManager.SNEAKING_SPEED, 0.0f, 1.0f);
+            this.updateMCAttribute(player, Attribute.PLAYER_SUBMERGED_MINING_SPEED, AttributeManager.SUBMERGED_MINING_SPEED, 0.0f, 20.0f);
+            this.updateMCAttribute(player, Attribute.PLAYER_SWEEPING_DAMAGE_RATIO, AttributeManager.SWEEPING_DAMAGE_RATIO, 0.0f, 1.0f);
+        }
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
+++ b/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
@@ -1956,6 +1956,7 @@ public class PlayerData {
         this.updateMCAttribute(player, Attribute.GENERIC_KNOCKBACK_RESISTANCE, AttributeManager.KNOCKBACK_RESIST, 0, 1.0);
         this.updateMCAttribute(player, Attribute.GENERIC_ARMOR_TOUGHNESS, AttributeManager.ARMOR_TOUGHNESS, 0, 20);
         // Stats added in 1.21+
+        
         this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_DAMAGE, AttributeManager.ATTACK_DAMAGE, 0.0f, 2048.0f);
         this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_KNOCKBACK, AttributeManager.ATTACK_KNOCKBACK, 0.0f, 5.0f);
         this.updateMCAttribute(player, Attribute.GENERIC_FLYING_SPEED, AttributeManager.FLYING_SPEED, 0.0f, 1024.0f);

--- a/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
+++ b/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
@@ -1952,12 +1952,34 @@ public class PlayerData {
         this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_SPEED, AttributeManager.ATTACK_SPEED, 0, 1024);
         this.updateMCAttribute(player, Attribute.GENERIC_ARMOR, AttributeManager.ARMOR, 0, 30);
         this.updateMCAttribute(player, Attribute.GENERIC_LUCK, AttributeManager.LUCK, -1024, 1024);
-        this.updateMCAttribute(player,
-                Attribute.GENERIC_KNOCKBACK_RESISTANCE,
-                AttributeManager.KNOCKBACK_RESIST,
-                0,
-                1.0);
+        this.updateMCAttribute(player, Attribute.GENERIC_KNOCKBACK_RESISTANCE, AttributeManager.KNOCKBACK_RESIST, 0, 1.0);
         this.updateMCAttribute(player, Attribute.GENERIC_ARMOR_TOUGHNESS, AttributeManager.ARMOR_TOUGHNESS, 0, 20);
+        // Stats added in 1.21+
+        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_DAMAGE, AttributeManager.ATTACK_DAMAGE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_ATTACK_KNOCKBACK, AttributeManager.ATTACK_KNOCKBACK, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_FLYING_SPEED, AttributeManager.FLYING_SPEED, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_FOLLOW_RANGE, AttributeManager.FOLLOW_RANGE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_MAX_ABSORPTION, AttributeManager.ABSORPTION, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_SCALE, AttributeManager.SCALE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_STEP_HEIGHT, AttributeManager.STEP_HEIGHT, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_JUMP_STRENGTH, AttributeManager.JUMP_STRENGTH, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_GRAVITY, AttributeManager.GRAVITY, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_SAFE_FALL_DISTANCE, AttributeManager.SAFE_FALL_DISTANCE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_FALL_DAMAGE_MULTIPLIER, AttributeManager.FALL_DAMAGE_MULTIPLIER, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_BURNING_TIME, AttributeManager.BURNING_TIME, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_EXPLOSION_KNOCKBACK_RESISTANCE, AttributeManager.EXPLOSION_KNOCKBACK_RESISTANCE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_MOVEMENT_EFFICIENCY, AttributeManager.MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_OXYGEN_BONUS, AttributeManager.OXYGEN_BONUS, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.GENERIC_WATER_MOVEMENT_EFFICIENCY, AttributeManager.WATER_MOVEMENT_EFFICIENCY, 0.0f, 1.0f);
+        // Player only stats 1.21+
+        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_INTERACTION_RANGE, AttributeManager.BLOCK_INTERACTION_RANGE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_ENTITY_INTERACTION_RANGE, AttributeManager.ENTITY_INTERACTION_RANGE, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_BLOCK_BREAK_SPEED, AttributeManager.BLOCK_BREAK_SPEED, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_MINING_EFFICIENCY, AttributeManager.MINING_EFFICIENCY, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_SNEAKING_SPEED, AttributeManager.SNEAKING_SPEED, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_SUBMERGED_MINING_SPEED, AttributeManager.SUBMERGED_MINING_SPEED, 0.0f, 1.0f);
+        this.updateMCAttribute(player, Attribute.PLAYER_SWEEPING_DAMAGE_RATIO, AttributeManager.SWEEPING_DAMAGE_RATIO, 0.0f, 1.0f);
+
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/manager/AttributeManager.java
+++ b/src/main/java/studio/magemonkey/fabled/manager/AttributeManager.java
@@ -45,27 +45,53 @@ import java.util.*;
  */
 public class AttributeManager implements IAttributeManager {
     // Keys for supported stat modifiers
-    public static final String HEALTH             = "health";
-    public static final String MANA               = "mana";
-    public static final String MANA_REGEN         = "mana-regen";
-    public static final String PHYSICAL_DAMAGE    = "physical-damage";
-    public static final String MELEE_DAMAGE       = "melee-damage";
-    public static final String PROJECTILE_DAMAGE  = "projectile-damage";
-    public static final String PHYSICAL_DEFENSE   = "physical-defense";
-    public static final String MELEE_DEFENSE      = "melee-defense";
-    public static final String PROJECTILE_DEFENSE = "projectile-defense";
-    public static final String SKILL_DAMAGE       = "skill-damage";
-    public static final String SKILL_DEFENSE      = "skill-defense";
-    public static final String MOVE_SPEED         = "move-speed";
-    public static final String ATTACK_SPEED       = "attack-speed";
-    public static final String ARMOR              = "armor";
-    public static final String LUCK               = "luck";
-    public static final String ARMOR_TOUGHNESS    = "armor-toughness";
-    public static final String EXPERIENCE         = "exp";
-    public static final String HUNGER             = "hunger";
-    public static final String HUNGER_HEAL        = "hunger-heal";
-    public static final String COOLDOWN           = "cooldown";
-    public static final String KNOCKBACK_RESIST   = "knockback-resist";
+    public static final String HEALTH                         = "health";
+    public static final String MANA                           = "mana";
+    public static final String MANA_REGEN                     = "mana-regen";
+    public static final String PHYSICAL_DAMAGE                = "physical-damage";
+    public static final String MELEE_DAMAGE                   = "melee-damage";
+    public static final String PROJECTILE_DAMAGE              = "projectile-damage";
+    public static final String PHYSICAL_DEFENSE               = "physical-defense";
+    public static final String MELEE_DEFENSE                  = "melee-defense";
+    public static final String PROJECTILE_DEFENSE             = "projectile-defense";
+    public static final String SKILL_DAMAGE                   = "skill-damage";
+    public static final String SKILL_DEFENSE                  = "skill-defense";
+    public static final String MOVE_SPEED                     = "move-speed";
+    public static final String ATTACK_SPEED                   = "attack-speed";
+    public static final String ARMOR                          = "armor";
+    public static final String LUCK                           = "luck";
+    public static final String ARMOR_TOUGHNESS                = "armor-toughness";
+    public static final String EXPERIENCE                     = "exp";
+    public static final String HUNGER                         = "hunger";
+    public static final String HUNGER_HEAL                    = "hunger-heal";
+    public static final String COOLDOWN                       = "cooldown";
+    public static final String KNOCKBACK_RESIST               = "knockback-resist";
+    // Attributes as of in 1.21+
+    // https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html
+    public static final String ATTACK_DAMAGE                  = "attack-damage";
+    public static final String ATTACK_KNOCKBACK               = "attack-knockback";
+    public static final String FLYING_SPEED                   = "flying-speed";
+    public static final String FOLLOW_RANGE                   = "follow-range";
+    public static final String ABSORPTION                     = "absorption";  
+    public static final String SCALE                          = "scale";
+    public static final String STEP_HEIGHT                    = "step-height";
+    public static final String JUMP_STRENGTH                  = "jump-strength";
+    public static final String GRAVITY                        = "gravity";
+    public static final String SAFE_FALL_DISTANCE             = "safe-fall-distance";
+    public static final String FALL_DAMAGE_MULTIPLIER         = "fall-damage-multiplier";
+    public static final String BURNING_TIME                   = "burning-time";
+    public static final String EXPLOSION_KNOCKBACK_RESISTANCE = "explosion-knockback-resistance";
+    public static final String MOVEMENT_EFFICIENCY            = "movement-efficiency";
+    public static final String OXYGEN_BONUS                   = "oxygen-bonus";
+    public static final String WATER_MOVEMENT_EFFICIENCY      = "water-movement-efficiency";
+    // Player only stats 1.21+
+    public static final String BLOCK_INTERACTION_RANGE        = "block-interaction-range";
+    public static final String ENTITY_INTERACTION_RANGE       = "entity-interaction-range";
+    public static final String BLOCK_BREAK_SPEED              = "block-break-speed";
+    public static final String MINING_EFFICIENCY              = "mining-efficiency";
+    public static final String SNEAKING_SPEED                 = "sneaking-speed";
+    public static final String SUBMERGED_MINING_SPEED         = "submerged-mining-speed";
+    public static final String SWEEPING_DAMAGE_RATIO          = "sweeping-damage-ratio";
 
     /**
      * Unsafe getter for the attribute data.


### PR DESCRIPTION
# Changelog

- Added 20+ new stats that players can modify with attributes, skills etc.
- They can be found here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/attribute/Attribute.html
- All names in the parenthesis can be added to the following wiki page with their description. https://github.com/magemonkeystudio/fabled/wiki/attributes#attribute-stats

## Generic Attributes

- Attack Damage (attack-damage) - Amount of damage an entity does by default.
- Attack Knockback (attack-knockback) - Amount of knockback an entity does by default.
- Flying Speed (flying-speed) - How fast an entity can fly.
- Follow Range (follow-range) - How far an entity will follow another entity before disengaging.
- Absorption (absorption) - How many absorption hearts persist when the potion effect ends. They will still be removed when damaged.
- Scale (scale) - The current size of the entity.
- Step Height (step-height) - The amount of blocks a player can step up without needing to jump. Will also allow entities to sneak down inclines that are less than their step height.
- Jump Strength (jump-strength) - How high an entity can jump.
- Gravity (gravity) - How fast an entity will fall.
- Safe Fall Distance (safe-fall-distance) - How far an entity can fall without taking damage.
- Fall Damage Multiplier (fall-damage-multiplier) - How much damage scales when an entity takes fall damage.
- Burning Time (burning-time) - How long an entity burns for when ignited.
- Explosion Knockback Resistance (explosion-knockback-resistance) - How much knockback is reduced when an explosion goes off.
- Movement Efficiency (movement-efficiency) - How efficient an entity moves on rough terrain.
- Oxygen Bonus (oxygen-bonus) - Increases how long an entity can stay underwater for without losing breath.
- Water Movement Efficiency (water-movement-efficiency) - Increases movement when in water only.

## Player Attributes

- Block Interaction Range (block-interaction-range) - Determines how far a player can mine, place or interact with blocks.
- Entity Interaction Range (entity-interaction-range) - Determines how far a player can hit or interact with other entities.
- Block Break Speed (block-break-speed) - Determines how fast a player can break blocks.
- Mining Efficiency (mining-efficiency) - Determines how fast a player can break a block when using the correct tool.
- Sneaking Speed (sneaking-speed) - Determines the movement speed of a player when they are sneaking.
- Submerged Mining Speed (submerged-mining-speed) - Determines how fast a player can mine when under water.
- Sweeping Damage Ration (sweeping-damage-ratio) - Determines how much damage is passed down to other entities damaged by the player's sweeping attack.