### PR TITLE
Added OnFirstJoin and OnLogin triggers with mana and cooldown checks

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnFirstJoinTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnFirstJoinTrigger.java
@@ -1,0 +1,61 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.PlayerJoinEvent;
+import studio.magemonkey.fabled.api.player.FabledPlayer;
+
+/**
+ * Fabled © 2024
+ * studio.magemonkey.fabled.dynamic.trigger.OnFirstJoinTrigger
+ */
+public class OnFirstJoinTrigger implements Trigger<PlayerJoinEvent> {
+
+    @Override
+    public String getKey() {
+        return "ON_FIRST_JOIN";
+    }
+
+    @Override
+    public Class<PlayerJoinEvent> getEvent() {
+        return PlayerJoinEvent.class;
+    }
+
+    @Override
+    public boolean shouldTrigger(final PlayerJoinEvent event, final int level, final Settings settings) {
+        FabledPlayer fabledPlayer = FabledPlayer.getPlayer(event.getPlayer());
+
+        if (!event.getPlayer().hasPlayedBefore()) {
+            // Verificação de mana
+            boolean checkMana = settings.getBool("Mana", false);
+            if (checkMana && fabledPlayer.getMana() < settings.getDouble("mana-requirement", 0)) {
+                return false; // Cancela se o jogador não tiver "mana" suficiente
+            }
+
+            // Verificação de cooldown
+            boolean checkCooldown = settings.getBool("Cooldown", false);
+            if (checkCooldown) {
+                // Lógica para verificar cooldown
+                return false; // Cancela se estiver em cooldown
+            }
+
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setValues(final PlayerJoinEvent event, final CastData data) {
+        data.put("player-name", event.getPlayer().getName());
+    }
+
+    @Override
+    public LivingEntity getCaster(final PlayerJoinEvent event) {
+        return event.getPlayer();
+    }
+
+    @Override
+    public LivingEntity getTarget(final PlayerJoinEvent event, final Settings settings) {
+        return event.getPlayer();
+    }
+}

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnLoginTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnLoginTrigger.java
@@ -1,0 +1,58 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.PlayerJoinEvent;
+import studio.magemonkey.fabled.api.player.FabledPlayer;
+
+/**
+ * Fabled © 2024
+ * studio.magemonkey.fabled.dynamic.trigger.OnLoginTrigger
+ */
+public class OnLoginTrigger implements Trigger<PlayerJoinEvent> {
+
+    @Override
+    public String getKey() {
+        return "ON_LOGIN";
+    }
+
+    @Override
+    public Class<PlayerJoinEvent> getEvent() {
+        return PlayerJoinEvent.class;
+    }
+
+    @Override
+    public boolean shouldTrigger(final PlayerJoinEvent event, final int level, final Settings settings) {
+        FabledPlayer fabledPlayer = FabledPlayer.getPlayer(event.getPlayer());
+
+        // Verificação de mana
+        boolean checkMana = settings.getBool("Mana", false);
+        if (checkMana && fabledPlayer.getMana() < settings.getDouble("mana-requirement", 0)) {
+            return false; // Cancela se o jogador não tiver "mana" suficiente
+        }
+
+        // Verificação de cooldown
+        boolean checkCooldown = settings.getBool("Cooldown", false);
+        if (checkCooldown) {
+            // Lógica para verificar cooldown
+            return false; // Cancela se estiver em cooldown
+        }
+
+        return true;
+    }
+
+    @Override
+    public void setValues(final PlayerJoinEvent event, final CastData data) {
+        data.put("player-name", event.getPlayer().getName());
+    }
+
+    @Override
+    public LivingEntity getCaster(final PlayerJoinEvent event) {
+        return event.getPlayer();
+    }
+
+    @Override
+    public LivingEntity getTarget(final PlayerJoinEvent event, final Settings settings) {
+        return event.getPlayer();
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds two new triggers: `OnFirstJoinTrigger` and `OnLoginTrigger`. 

### Details
- **OnFirstJoinTrigger:** Checks if the player has enough mana when they first join the game. It will only trigger if the player is joining for the first time.
- **OnLoginTrigger:** Similar to `OnFirstJoinTrigger`, but this one checks for mana and cooldown on every login.

### Changes
- Added checks for mana cost and cooldown conditions.
- Updated the handling of player events to ensure proper functionality within the existing Fabled framework.

### Notes
Please review the implementations and let me know if any modifications are needed.

Note: remember that I'm still getting used to it, sorry for any mistakes