### PR TITLE
New Triggers (OnInteract,OnFirstJoin,OnLogin) First Try

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnFirstJoinTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnFirstJoinTrigger.java
@@ -1,0 +1,92 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.PlayerJoinEvent;
+import studio.magemonkey.fabled.api.player.FabledPlayer;
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * Fabled © 2024
+ * studio.magemonkey.fabled.dynamic.trigger.OnFirstJoinTrigger
+ * 
+ * This trigger is activated when a player joins the server for the first time.
+ */
+public class OnFirstJoinTrigger implements Trigger<PlayerJoinEvent> {
+
+    @Override
+    public String getKey() {
+        return "ON_FIRST_JOIN";
+    }
+
+    @Override
+    public Class<PlayerJoinEvent> getEvent() {
+        return PlayerJoinEvent.class;
+    }
+
+    @Override
+    public boolean shouldTrigger(final PlayerJoinEvent event, final int level, final Settings settings) {
+        // Check if this is the first time the player has joined the server
+        if (event.getPlayer().hasPlayedBefore()) {
+            return false; // Not the first join
+        }
+
+        // At this point, the player is in their first join event
+        FabledPlayer fabledPlayer = FabledPlayer.getPlayer(event.getPlayer());
+
+        // Mana and cooldown checks can now be applied
+        boolean hasEnoughMana = hasRequiredMana(fabledPlayer, settings);
+        boolean notOnCooldown = !isOnCooldown(fabledPlayer, settings);
+
+        // Only trigger if the player meets all conditions
+        return hasEnoughMana && notOnCooldown;
+    }
+
+    /**
+     * Checks if the player has the required mana to trigger the event.
+     * 
+     * @param player   the FabledPlayer object representing the player
+     * @param settings the Settings object containing configuration values
+     * @return true if the player has enough mana or if mana check is disabled
+     */
+    private boolean hasRequiredMana(FabledPlayer player, Settings settings) {
+        boolean checkMana = settings.getBool("Mana", false);
+        double requiredMana = settings.getDouble("mana-requirement", 0);
+        return !checkMana || player.getMana() >= requiredMana;
+    }
+
+    /**
+     * Checks if the player is currently on cooldown and prevents the event from 
+     * being triggered if true.
+     * 
+     * @param player   the FabledPlayer object representing the player
+     * @param settings the Settings object containing configuration values
+     * @return true if the player is on cooldown
+     */
+    private boolean isOnCooldown(FabledPlayer player, Settings settings) {
+        boolean checkCooldown = settings.getBool("Cooldown", false);
+        if (checkCooldown) {
+            // Implement your cooldown logic here. For example:
+            long lastJoin = player.getLastJoinTime(); // Assumindo que esse método existe
+            long cooldownTime = settings.getLong("cooldown-time", 60000); // Tempo em milissegundos
+            return (System.currentTimeMillis() - lastJoin) < cooldownTime;
+        }
+        return false; // Não está em cooldown se a verificação estiver desativada
+    }
+
+    @Override
+    public void setValues(final PlayerJoinEvent event, final CastData data) {
+        // Set event-related data, such as the player's name
+        data.put("player-name", event.getPlayer().getName());
+    }
+
+    @Override
+    public LivingEntity getCaster(final PlayerJoinEvent event) {
+        return event.getPlayer();
+    }
+
+    @Override
+    public LivingEntity getTarget(final PlayerJoinEvent event, final Settings settings) {
+        return event.getPlayer();
+    }
+}

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnInteract.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnInteract.java
@@ -1,0 +1,98 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.SkillInteractEvent;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
+
+/**
+ * Fabled © 2024
+ * studio.magemonkey.fabled.dynamic.trigger.InteractTrigger
+ */
+public class InteractTrigger extends SkillTrigger {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getKey() {
+        return "ON_INTERACT";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LivingEntity getCaster(SkillInteractEvent event) {
+        return event.getPlayer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LivingEntity getTarget(SkillInteractEvent event, Settings settings) {
+        // Definindo o alvo baseado na configuração
+        if (isUsingTarget(settings)) {
+            return event.getTarget();
+        } else {
+            return event.getPlayer();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValues(SkillInteractEvent event, CastData data) {
+        data.put("target-type", event.getTarget().getType().toString());
+        data.put("target-name", event.getTarget().getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean shouldTrigger(SkillInteractEvent event, int level, Settings settings) {
+        String mobType = settings.getString("MobType", "ALL");
+        if (!mobType.equalsIgnoreCase("ALL") &&
+                !event.getTarget().getType().toString().equalsIgnoreCase(mobType)) {
+            return false;
+        }
+
+        // Hook para Citizens NPC se necessário
+        if (settings.has("CitizensNPCID")) {
+            int npcId = settings.getInt("CitizensNPCID");
+            if (event.getTarget().hasMetadata("NPC")) {
+                int targetNpcId = getNpcId(event.getTarget());
+                return targetNpcId == npcId;
+            }
+            return false;
+        }
+
+        return true; // Se passou em todas as verificações, o trigger deve ocorrer
+    }
+
+    /**
+     * Helper para pegar o ID do NPC Citizens
+     */
+    private int getNpcId(LivingEntity entity) {
+        // Verifica se o NPC é do Citizens e retorna o ID
+        if (CitizensAPI.getNPCRegistry().isNPC(entity)) {
+            NPC npc = CitizensAPI.getNPCRegistry().getNPC(entity);
+            return npc.getId(); // Retorna o ID do NPC
+        }
+        return -1; // Retorna -1 se não for um NPC válido
+    }
+
+    /**
+     * Definir se está usando o alvo de interação
+     */
+    private boolean isUsingTarget(Settings settings) {
+        return settings.getString("use-target", "true").equalsIgnoreCase("true");
+    }
+}

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnLoginTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/OnLoginTrigger.java
@@ -1,0 +1,85 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.PlayerJoinEvent;
+import studio.magemonkey.fabled.api.player.FabledPlayer;
+import org.bukkit.entity.LivingEntity;
+
+/**
+ * Fabled © 2024
+ * studio.magemonkey.fabled.dynamic.trigger.OnLoginTrigger
+ * 
+ * This trigger is activated when a player joins the server. It can check for
+ * mana and cooldown requirements before allowing further actions.
+ */
+public class OnLoginTrigger implements Trigger<PlayerJoinEvent> {
+
+    @Override
+    public String getKey() {
+        return "ON_LOGIN";
+    }
+
+    @Override
+    public Class<PlayerJoinEvent> getEvent() {
+        return PlayerJoinEvent.class;
+    }
+
+    @Override
+    public boolean shouldTrigger(final PlayerJoinEvent event, final int level, final Settings settings) {
+        FabledPlayer fabledPlayer = FabledPlayer.getPlayer(event.getPlayer());
+
+        // Check for mana and cooldown using helper methods
+        return hasRequiredMana(fabledPlayer, settings) && !isOnCooldown(fabledPlayer, settings);
+    }
+
+    /**
+     * Checks if the player has the required mana to trigger the event.
+     * 
+     * @param player   the FabledPlayer object representing the player
+     * @param settings the Settings object containing configuration values
+     * @return true if the player has enough mana or if mana check is disabled
+     */
+    private boolean hasRequiredMana(FabledPlayer player, Settings settings) {
+        boolean checkMana = settings.getBool("Mana", false);
+        double requiredMana = settings.getDouble("mana-requirement", 0);
+        return !checkMana || player.getMana() >= requiredMana;
+    }
+
+    /**
+     * Checks if the player is currently on cooldown and prevents the event from 
+     * being triggered if true.
+     * 
+     * @param player   the FabledPlayer object representing the player
+     * @param settings the Settings object containing configuration values
+     * @return true if the player is on cooldown
+     */
+    private boolean isOnCooldown(FabledPlayer player, Settings settings) {
+        boolean checkCooldown = settings.getBool("Cooldown", false);
+        if (checkCooldown) {
+            // Implement your cooldown logic here. For example:
+            long lastLogin = player.getLastLoginTime(); // Assumindo que esse método existe
+            long cooldownTime = settings.getLong("cooldown-time", 60000); // Tempo em milissegundos
+            return (System.currentTimeMillis() - lastLogin) < cooldownTime;
+        }
+        return false; // Não está em cooldown se a verificação estiver desativada
+    }
+
+    @Override
+    public void setValues(final PlayerJoinEvent event, final CastData data) {
+        // Store player's name in the data object
+        data.put("player-name", event.getPlayer().getName());
+    }
+
+    @Override
+    public LivingEntity getCaster(final PlayerJoinEvent event) {
+        // The player who triggered the event is considered the caster
+        return event.getPlayer();
+    }
+
+    @Override
+    public LivingEntity getTarget(final PlayerJoinEvent event, final Settings settings) {
+        // The event target is the player themselves
+        return event.getPlayer();
+    }
+}


### PR DESCRIPTION
Hello! This pull request introduces three new triggers: OnInteract, OnLogin, and OnFirstJoin. These triggers allow specific actions to be performed when players interact with entities, join the server, or log in for the first time.

New features include mana checks and cooldown management.

Take a look and let me know if you have any questions or feedback. Thanks