### PR TITLE
Placeholders should be case sensitive

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/util/PlaceholderUtil.java
+++ b/src/main/java/studio/magemonkey/fabled/util/PlaceholderUtil.java
@@ -157,7 +157,7 @@ public class PlaceholderUtil {
     }
 
     public static String replace(OfflinePlayer player, String identifier) {
-        List<String> arguments   = new ArrayList<>(Arrays.asList(identifier.toLowerCase().strip().split("_")));
+        List<String> arguments   = new ArrayList<>(Arrays.asList(identifier.strip().split("_")));
         String       placeholder = arguments.remove(0);
         return actions.getOrDefault(placeholder, (a, b, c) -> {
 


### PR DESCRIPTION
Solves #1214

Placeholders that have improper capitalization will not longer work. For example, using %FABLED_class% will not return the class name, but %fabled_class% will. This format follows the usage of other plugins as well. This fix does allow for capitalized group names to return expected results going forward!