### PR TITLE
[editor] Apply default values for new fields

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -58,5 +58,5 @@ export const localStore = <T>(key: string, def: T) => {
 
 export const parseBool = (val: string | boolean | undefined) => {
 	if (typeof val === 'boolean') return val;
-	return val === 'true';
+	return val?.toLowerCase().trim() === 'true';
 };

--- a/src/api/options/attributeselect.svelte.ts
+++ b/src/api/options/attributeselect.svelte.ts
@@ -45,7 +45,11 @@ export default class AttributeSelect extends Requirements implements ComponentOp
 	};
 
 	deserialize = (yaml: Unknown) => {
-		this.data.base  = <number>yaml[`${this.key}-base`] || 0;
-		this.data.scale = <number>yaml[`${this.key}-scale`] || 0;
+		const valBase = <number>yaml[`${this.key}-base`];
+		if (valBase !== undefined)
+			this.data.base = valBase;
+		const valScale = <number>yaml[`${this.key}-scale`];
+		if (valScale !== undefined)
+			this.data.scale = valScale;
 	};
 }

--- a/src/api/options/booleanselect.svelte.ts
+++ b/src/api/options/booleanselect.svelte.ts
@@ -38,5 +38,9 @@ export default class BooleanSelect extends Requirements implements ComponentOpti
 		return this.data ? 'true' : '';
 	};
 
-	deserialize = (yaml: Unknown) => this.data = parseBool(<boolean | string>yaml[this.key]);
+	deserialize = (yaml: Unknown) => {
+		const val = <boolean | string | undefined>yaml[this.key];
+		if (val !== undefined)
+			this.data = parseBool(val);
+	}
 }

--- a/src/api/options/colorselect.svelte.ts
+++ b/src/api/options/colorselect.svelte.ts
@@ -35,5 +35,9 @@ export default class ColorSelect extends Requirements implements ComponentOption
 		return this.data;
 	};
 
-	deserialize = (yaml: Unknown) => this.data = <string>yaml[this.key] || '#12cfab';
+	deserialize = (yaml: Unknown) => {
+		const val = <string>yaml[this.key];
+		if (val !== undefined)
+			this.data = val;
+	};
 }

--- a/src/api/options/doubleselect.svelte.ts
+++ b/src/api/options/doubleselect.svelte.ts
@@ -36,5 +36,9 @@ export default class DoubleSelect extends Requirements implements ComponentOptio
 
 	getSummary = (): string => this.data.toString();
 
-	deserialize = (yaml: Unknown) => this.data = <number>yaml[this.key] || 0;
+	deserialize = (yaml: Unknown) => {
+		const val = <number>yaml[this.key];
+		if (val !== undefined)
+			this.data = val;
+	};
 }

--- a/src/api/options/dropdownselect.svelte.ts
+++ b/src/api/options/dropdownselect.svelte.ts
@@ -66,9 +66,11 @@ export default class DropdownSelect extends Requirements implements ComponentOpt
 	};
 
 	deserialize = (yaml: Unknown) => {
-		this.data.selected = <string[] | string>yaml[this.key];
+		const val = <string[] | string>yaml[this.key];
 		// If selected is not a list and multiple is true, convert it to a list
-		if (this.data.multiple && !(this.data.selected instanceof Array)) this.data.selected = [this.data.selected];
-		else if (!this.data.multiple && this.data.selected instanceof Array) this.data.selected = this.data.selected[0];
+		if (val !== undefined) {
+			if (this.data.multiple && !(val instanceof Array)) this.data.selected = [val];
+			else if (!this.data.multiple && val instanceof Array) this.data.selected = val[0];
+		}
 	};
 }

--- a/src/api/options/dropdownselect.svelte.ts
+++ b/src/api/options/dropdownselect.svelte.ts
@@ -71,6 +71,7 @@ export default class DropdownSelect extends Requirements implements ComponentOpt
 		if (val !== undefined) {
 			if (this.data.multiple && !(val instanceof Array)) this.data.selected = [val];
 			else if (!this.data.multiple && val instanceof Array) this.data.selected = val[0];
+			else this.data.selected = val;
 		}
 	};
 }

--- a/src/api/options/enchantselect.svelte.ts
+++ b/src/api/options/enchantselect.svelte.ts
@@ -43,11 +43,11 @@ export default class EnchantSelect extends Requirements implements ComponentOpti
 	getSummary = (): string => this.data.enchants.map(({ name, level }) => `${name} ${level}`).join(', ');
 
 	deserialize = (yaml: Unknown) => {
-		const raw = <string[]>yaml[this.key] || [];
-
-		this.data.enchants = raw.map((str) => {
-			const [name, level] = str.split(':');
-			return { name, level: parseInt(level) };
-		});
+		const raw = <string[]>yaml[this.key];
+		if (raw !== undefined)
+			this.data.enchants = raw.map((str) => {
+				const [name, level] = str.split(':');
+				return { name, level: parseInt(level) };
+			});
 	};
 }

--- a/src/api/options/intselect.svelte.ts
+++ b/src/api/options/intselect.svelte.ts
@@ -38,5 +38,9 @@ export default class IntSelect extends Requirements implements ComponentOption {
 		return this.data.toString();
 	};
 
-	deserialize = (yaml: Unknown) => this.data = <number>yaml[this.key] || 0;
+	deserialize = (yaml: Unknown) => {
+		const val = <number>yaml[this.key];
+		if (val !== undefined)
+			this.data = val;
+	};
 }

--- a/src/api/options/materialselect.svelte.ts
+++ b/src/api/options/materialselect.svelte.ts
@@ -36,5 +36,9 @@ export default class MaterialSelect extends Requirements implements ComponentOpt
 
 	getSummary = (): string => this.data.material;
 
-	deserialize = (yaml: Unknown) => this.data.material = <string>yaml[this.key] || 'Dirt';
+	deserialize = (yaml: Unknown) => {
+		const val = <string | undefined>yaml[this.key];
+		if (val !== undefined)
+			this.data.material = val;
+	};
 }

--- a/src/api/options/stringlistselect.svelte.ts
+++ b/src/api/options/stringlistselect.svelte.ts
@@ -34,5 +34,9 @@ export default class StringListSelect extends Requirements implements ComponentO
 
 	getSummary = (): string => this.data?.value ? this.data.value.join(', ') : '';
 
-	deserialize = (yaml: Unknown) => this.data.value = <string[]>yaml[this.key] || [];
+	deserialize = (yaml: Unknown) => {
+		const val = <string[]>yaml[this.key];
+		if (val !== undefined)
+			this.data.value = val;
+	};
 }

--- a/src/api/options/stringselect.svelte.ts
+++ b/src/api/options/stringselect.svelte.ts
@@ -36,5 +36,9 @@ export default class StringSelect extends Requirements implements ComponentOptio
 
 	getSummary = (): string => this.data;
 
-	deserialize = (yaml: Unknown) => this.data = <string>yaml[this.key] || '';
+	deserialize = (yaml: Unknown) => {
+		const val = <string>yaml[this.key];
+		if (val !== undefined)
+			this.data = val;
+	};
 }


### PR DESCRIPTION
This PR ensures that proper default values are applied for new fields
This also ensures the boolean conversion of legacy dynamic files works (they are `"True"` with a capital `T`, breaking migrations)