### PR TITLE
Ensure correct conversion of disguise types

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/hook/DisguiseHook.java
+++ b/src/main/java/studio/magemonkey/fabled/hook/DisguiseHook.java
@@ -34,6 +34,7 @@ import me.libraryaddict.disguise.utilities.DisguiseValues;
 import me.libraryaddict.disguise.utilities.reflection.FakeBoundingBox;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import studio.magemonkey.fabled.log.Logger;
@@ -54,7 +55,8 @@ public class DisguiseHook {
     public static void disguiseMob(LivingEntity target, String type, boolean adult) {
         try {
             String       name        = target.getCustomName();
-            DisguiseType disguise    = DisguiseType.valueOf(type.toUpperCase(Locale.US).replace(" ", "_"));
+            DisguiseType disguise = DisguiseType.getType(
+                    EntityType.valueOf(type.toUpperCase(Locale.US).replace(" ", "_")));
             MobDisguise  mobDisguise = new MobDisguise(disguise, adult);
             DisguiseAPI.disguiseToAll(target, mobDisguise);
             if (name != null)
@@ -92,7 +94,8 @@ public class DisguiseHook {
     public static void disguiseMisc(LivingEntity target, String type, int data) {
         try {
             String       name         = target.getCustomName();
-            DisguiseType disguise     = DisguiseType.valueOf(type.toUpperCase(Locale.US).replace(" ", "_"));
+            DisguiseType disguise = DisguiseType.getType(
+                    EntityType.valueOf(type.toUpperCase(Locale.US).replace(" ", "_")));
             MiscDisguise miscDisguise = new MiscDisguise(disguise, data);
             DisguiseAPI.disguiseToAll(target, miscDisguise);
             if (name != null)
@@ -112,7 +115,8 @@ public class DisguiseHook {
     public static void disguiseMisc(LivingEntity target, String type, Material mat) {
         try {
             String       name         = target.getCustomName();
-            DisguiseType disguise     = DisguiseType.valueOf(type.toUpperCase(Locale.US).replace(" ", "_"));
+            DisguiseType disguise = DisguiseType.getType(
+                    EntityType.valueOf(type.toUpperCase(Locale.US).replace(" ", "_")));
             MiscDisguise miscDisguise = new MiscDisguise(disguise, mat);
             DisguiseAPI.disguiseToAll(target, miscDisguise);
             if (name != null)


### PR DESCRIPTION
This PR ensures conversion between editor enum values & `DisguiseType` is correct
A newer Minecraft version may have different entity names than those in `DisguiseType` enums
For example, end crystals are called `END_CRYSTAL` in new Minecraft versions, but it's still called `ENDER_CRYSTAL` in `DisguiseType`, yielding errors like `Invalid misc disguise type: End crystal`
By converting the type to a native `EntityType` then converting it back to a `DisguiseType`, we avoid naming inconsistencies across different versions of LibDisguise & Minecraft