### PR TITLE
Ability to append to existing target groups in Remember Target

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RememberTargetsMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RememberTargetsMechanic.java
@@ -62,13 +62,14 @@ public class RememberTargetsMechanic extends MechanicComponent {
         String key = settings.getString(KEY);
         boolean overwrite = settings.getBool(OVERWRITE, true);
         CastData castData = DynamicSkill.getCastData(caster);
+        Object rawTargets = castData.getRaw(key);
 
-        if (!overwrite && castData.getRaw(key) instanceof List<?>) {
+        if (!overwrite && rawTargets instanceof List<?>) {
             @SuppressWarnings("unchecked")
-            List<LivingEntity> originalTargets = (List<LivingEntity>) castData.getRaw(key);
+            List<LivingEntity> originalTargets = (List<LivingEntity>) rawTargets;
             originalTargets.addAll(targets);
         } else {
-            DynamicSkill.getCastData(caster).put(key, targets);
+            castData.put(key, targets);
         }
         return true;
     }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RememberTargetsMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RememberTargetsMechanic.java
@@ -63,9 +63,9 @@ public class RememberTargetsMechanic extends MechanicComponent {
         boolean overwrite = settings.getBool(OVERWRITE, true);
         CastData castData = DynamicSkill.getCastData(caster);
 
-        if (!overwrite && castData.getRaw(key) instanceof List<?> rawTargets) {
+        if (!overwrite && castData.getRaw(key) instanceof List<?>) {
             @SuppressWarnings("unchecked")
-            List<LivingEntity> originalTargets = (List<LivingEntity>) rawTargets;
+            List<LivingEntity> originalTargets = (List<LivingEntity>) castData.getRaw(key);
             originalTargets.addAll(targets);
         } else {
             DynamicSkill.getCastData(caster).put(key, targets);

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RememberTargetsMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RememberTargetsMechanic.java
@@ -27,6 +27,7 @@
 package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.entity.LivingEntity;
+import studio.magemonkey.fabled.api.CastData;
 import studio.magemonkey.fabled.dynamic.DynamicSkill;
 
 import java.util.List;
@@ -36,6 +37,7 @@ import java.util.List;
  */
 public class RememberTargetsMechanic extends MechanicComponent {
     private static final String KEY = "key";
+    private static final String OVERWRITE = "overwrite";
 
     @Override
     public String getKey() {
@@ -53,12 +55,21 @@ public class RememberTargetsMechanic extends MechanicComponent {
      */
     @Override
     public boolean execute(LivingEntity caster, int level, List<LivingEntity> targets, boolean force) {
-        if (targets.size() == 0 || !settings.has(KEY)) {
+        if (targets.isEmpty() || !settings.has(KEY)) {
             return false;
         }
 
         String key = settings.getString(KEY);
-        DynamicSkill.getCastData(caster).put(key, targets);
+        boolean overwrite = settings.getBool(OVERWRITE, true);
+        CastData castData = DynamicSkill.getCastData(caster);
+
+        if (!overwrite && castData.getRaw(key) instanceof List<?> rawTargets) {
+            @SuppressWarnings("unchecked")
+            List<LivingEntity> originalTargets = (List<LivingEntity>) rawTargets;
+            originalTargets.addAll(targets);
+        } else {
+            DynamicSkill.getCastData(caster).put(key, targets);
+        }
         return true;
     }
 }


### PR DESCRIPTION
Offers an option `overwrite` to indicate whether to overwrite any existing target groups with the same ID, or append them to it instead