### PR TITLE
Fixed DamageBuffMechanic & DefenseBuffMechanic for skills

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageBuffMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageBuffMechanic.java
@@ -37,10 +37,11 @@ import java.util.List;
  * Applies a flag to each target
  */
 public class DamageBuffMechanic extends MechanicComponent {
-    private static final String TYPE    = "type";
-    private static final String SKILL   = "skill";
-    private static final String VALUE   = "value";
-    private static final String SECONDS = "seconds";
+    private static final String TYPE           = "type";
+    private static final String SKILL          = "skill";
+    private static final String VALUE          = "value";
+    private static final String SECONDS        = "seconds";
+    private static final String CLASSIFICATION = "classification";
 
     @Override
     public String getKey() {
@@ -54,14 +55,14 @@ public class DamageBuffMechanic extends MechanicComponent {
         }
 
         boolean skill   = settings.getString(SKILL, "false").equalsIgnoreCase("true");
-        boolean percent = settings.getString(TYPE, "flat").toLowerCase().equals("multiplier");
+        boolean percent = settings.getString(TYPE, "flat").equalsIgnoreCase("multiplier");
         double  value   = parseValues(caster, VALUE, level, 1.0);
         double  seconds = parseValues(caster, SECONDS, level, 3.0);
         int     ticks   = (int) (seconds * 20);
         for (LivingEntity target : targets) {
-            BuffManager.addBuff(
-                    target,
-                    skill ? BuffType.SKILL_DAMAGE : BuffType.DAMAGE,
+            BuffManager.getBuffData(target, true).addBuff(
+                    (skill ? BuffType.SKILL_DAMAGE : BuffType.DAMAGE).getLocalizedName(),
+                    skill ? settings.getString(CLASSIFICATION, "default") : null,
                     new Buff(this.skill.getName(), value, percent),
                     ticks);
         }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DefenseBuffMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DefenseBuffMechanic.java
@@ -37,10 +37,11 @@ import java.util.List;
  * Applies a flag to each target
  */
 public class DefenseBuffMechanic extends MechanicComponent {
-    private static final String TYPE    = "type";
-    private static final String SKILL   = "skill";
-    private static final String VALUE   = "value";
-    private static final String SECONDS = "seconds";
+    private static final String TYPE           = "type";
+    private static final String SKILL          = "skill";
+    private static final String VALUE          = "value";
+    private static final String SECONDS        = "seconds";
+    private static final String CLASSIFICATION = "classification";
 
     @Override
     public String getKey() {
@@ -63,14 +64,14 @@ public class DefenseBuffMechanic extends MechanicComponent {
         }
 
         boolean skill   = settings.getString(SKILL, "false").equalsIgnoreCase("true");
-        boolean percent = settings.getString(TYPE, "flat").toLowerCase().equals("multiplier");
+        boolean percent = settings.getString(TYPE, "flat").equalsIgnoreCase("multiplier");
         double  value   = parseValues(caster, VALUE, level, 1.0);
         double  seconds = parseValues(caster, SECONDS, level, 3.0);
         int     ticks   = (int) (seconds * 20);
         for (LivingEntity target : targets) {
-            BuffManager.addBuff(
-                    target,
-                    skill ? BuffType.SKILL_DEFENSE : BuffType.DEFENSE,
+            BuffManager.getBuffData(target, true).addBuff(
+                    (skill ? BuffType.SKILL_DEFENSE : BuffType.DEFENSE).getLocalizedName(),
+                    skill ? settings.getString(CLASSIFICATION, "default") : null,
                     new Buff(this.skill.getName(), value, percent),
                     ticks);
         }


### PR DESCRIPTION
[b6b81fa7 ](https://github.com/magemonkeystudio/fabled/commit/b6b81fa7be17bf351e21caa82aa785d78697ecea) introduced a bug for DamageBuffMechanic DefenseBuffMechanic of skills, where they wouldn't work at all due to the lack of a `classification` field, this PR adds that with an appropriate default value for those not using said feature.
This PR also closes #1219 , offering a more elegant and customizable solution.